### PR TITLE
Fix cache not being cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2023-03-27
+### Fixed
+* Fixed possible caching issue for users who already loaded a previous nova-ckeditor4-field version, causing their cached script not being updated when the package is updated.
+
 ## [2.0.4] - 2022-11-09
 ### Fixed
 * Same as https://github.com/waynestate/nova-text-copy-field/pull/7 but don't display the TextCopy button to the right of the form field by @chrispelzer https://github.com/waynestate/nova-text-copy-field/pull/9

--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -16,8 +16,8 @@ class FieldServiceProvider extends ServiceProvider
     public function boot()
     {
         Nova::serving(function (ServingNova $event) {
-            Nova::script('text-copy', __DIR__.'/../dist/js/field.js');
-            Nova::style('text-copy', __DIR__.'/../dist/css/field.css');
+            Nova::script('text-copy-v-2-0-5', __DIR__.'/../dist/js/field.js');
+            Nova::style('text-copy-v-2-0-5', __DIR__.'/../dist/css/field.css');
         });
     }
 


### PR DESCRIPTION
due to the scripts being cached, we need a way for the field.js to be refreshed when it is updated. It seems Nova doesn't clear the cache properly so make sure the script name is unique so the cache is unique

https://github.com/laravel/nova-issues/issues/658